### PR TITLE
It is no more possible to read resource-labels generated in the release 1102.vde5663d777cf

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,28 @@ Reassign | STEAL | Reserves a resource that may be or not be reserved by some pe
 Reset | UNLOCK | Reset a resource that may be reserved, locked or queued.
 Note | RESERVE | Add or edit resource note.
 
+## Upgrading from 1102.vde5663d777cf
+
+Due an [issue](https://github.com/jenkinsci/lockable-resources-plugin/issues/434) is no more possible to read resource-labels from config file org.jenkins.plugins.lockableresources.LockableResourcesManager.xml generated in the release [1102.vde5663d777cf](https://github.com/jenkinsci/lockable-resources-plugin/releases/tag/1102.vde5663d777cf)
+
+This does not effect instances used [Configuration-as-Code](https://github.com/jenkinsci/configuration-as-code-plugin) plugin.
+
+A possible solution is, to remove the `<string>` tags from your `org.jenkins.plugins.lockableresources.LockableResourcesManager.xml`config file manually, before you upgrade to new version (Keep in mind that a backup is still good idea).
+
+Example:
+
+this one
+```
+<labels>
+  <string>tests-integration-installation</string>
+</labels>
+```
+to
+```
+<labels>
+  tests-integration-installation
+</labels>
+```
 
 ## Changelog
 


### PR DESCRIPTION
It is not possible to read resource-labels from config file org.jenkins.plugins.lockableresources.LockableResourcesManager.xml generated in the release [1102.vde5663d777cf](https://github.com/jenkinsci/lockable-resources-plugin/releases/tag/1102.vde5663d777cf)

resolve #434

### Testing done

+ create config with resource-labels in 1102
+ update to 1106 - No label are there
+ remove all `<string>` and `</string>` from org.jenkins.plugins.lockableresources.LockableResourcesManager.xml
+ restart jenkins again - all labels are there

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- ~~[ ] There is automated testing or an explanation that explains why this change has no tests.~~
- ~~[ ] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.~~
- ~~[ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).~~
- ~~[ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.~~
- ~~[ ] For new APIs and extension points, there is a link to at least one consumer.~~
- ~~[ ] Any localizations are transferred to *.properties files.~~
- ~~[ ] Changes in the interface are documented also as [examples](src/doc/examples/readme.md).~~

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There is at least one (1) approval for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] java code changes are tested by automated test.
